### PR TITLE
Change pizza-event value from "1" to "expired"

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -86,7 +86,7 @@ pizza args =
     notifyIn t = do
         sendTimeUp <- asIO $ do
             respondNick "Time is up!"
-            publish pizzaTopic "1"
+            publish pizzaTopic "expired"
         lift . forkIO $ do
             threadDelay t
             sendTimeUp


### PR DESCRIPTION
OpenHAB has some issues with integers on MQTT-Events.
